### PR TITLE
Fixed keynames for destination bucket (error logging no longer breaks)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,7 @@
 A Github copy of Joe Emison's multi-cloud-mirror script (https://code.google.com/p/multi-cloud-mirror/ )
 
 The latest copy of the script was on https://github.com/PeerJ/multi-cloud-mirror and this repo is my fork of it for some changes and fixes I needed. I'll create pull requests for all of my changes, so you really shouldn't be checking out my fork ;)
+
+Changes so far:
+* fixed a small bug in the error reporting
+* tried adding multipart upload (thanks to http://codeinpython.blogspot.de/2015/08/s3-upload-large-files-to-amazon-using.html )

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # multi-cloud-mirror
-A Github copy of Joe Masters Emison's multi-cloud-mirror script (https://code.google.com/p/multi-cloud-mirror/ )
+A Github copy of Joe Emison's multi-cloud-mirror script (https://code.google.com/p/multi-cloud-mirror/ )
 
 The latest copy of the script was on https://github.com/PeerJ/multi-cloud-mirror and this repo is my fork of it for some changes and fixes I needed. I'll create pull requests for all of my changes, so you really shouldn't be checking out my fork ;)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# multi-cloud-mirror
+A Github copy of Joe Masters Emison's multi-cloud-mirror script (https://code.google.com/p/multi-cloud-mirror/ )
+
+The latest copy of the script was on https://github.com/PeerJ/multi-cloud-mirror and this repo is my fork of it for some changes and fixes I needed. I'll create pull requests for all of my changes, so you really shouldn't be checking out my fork ;)

--- a/multi_cloud_mirror.py
+++ b/multi_cloud_mirror.py
@@ -339,11 +339,11 @@ class MultiCloudMirror:
                      try:
                         job.get() # This will re-raise the exception.
                      except (S3ResponseError, S3PermissionsError, S3CopyError) as err:
-                        self.logItem("Error in %s %s to/from S3 bucket %s: [%d] %s" % (job_dict['task'], job_dict['myKeyName'], job_dict['s3BucketName'], err.status, err.reason), self.LOG_WARN)
+                        self.logItem("Error in %s %s to/from S3 bucket %s: [%d] %s" % (job_dict['task'], job_dict['myKeyName'], job_dict['destBucketName'], err.status, err.reason), self.LOG_WARN)
                         self.jobs.remove(job_dict)
                      except (ResponseError, NoSuchContainer, InvalidContainerName, InvalidUrl, ContainerNotPublic, AuthenticationFailed, AuthenticationError,
                              NoSuchObject, InvalidObjectName, InvalidMetaName, InvalidMetaValue, InvalidObjectSize, IncompleteSend), err:
-                        self.logItem("Error in %s %s to/from to CF container %s: %s" % (job_dict['task'], job_dict['myKeyName'], job_dict['cfBucketName'], err), self.LOG_WARN)
+                        self.logItem("Error in %s %s to/from to CF container %s: %s" % (job_dict['task'], job_dict['myKeyName'], job_dict['destBucketName'], err), self.LOG_WARN)
                         self.jobs.remove(job_dict)
                      except MultiCloudMirrorException as err:
                         self.logItem("MultiCloudMirror error in %s %s: %s" % (job_dict['task'], job_dict['myKeyName'], str(err)), self.LOG_WARN)

--- a/multi_cloud_mirror.py
+++ b/multi_cloud_mirror.py
@@ -82,8 +82,8 @@ def copyToS3(srcBucketName, myKeyName, destBucketName,tmpFile):
       newObj = destBucket.get_key(myKeyName)
 
    source_size = os.stat(tmpFile).st_size
-   min_mp_size = 500*1024*1024;
-   bytes_per_chunk = 50 * 1024 * 1024
+   min_mp_size = 50*1024*1024;
+   bytes_per_chunk = 10 * 1024 * 1024
    if source_size / bytes_per_chunk > 1024:
       bytes_per_chunk = ceil(source_size / 1024)
 

--- a/multi_cloud_mirror.py
+++ b/multi_cloud_mirror.py
@@ -82,10 +82,14 @@ def copyToS3(srcBucketName, myKeyName, destBucketName,tmpFile):
       newObj = destBucket.get_key(myKeyName)
 
    source_size = os.stat(tmpFile).st_size
-   bytes_per_chunk = 5000*1024*1024
+   min_mp_size = 500*1024*1024;
+   bytes_per_chunk = 50 * 1024 * 1024
+   if source_size / bytes_per_chunk > 1024:
+      bytes_per_chunk = ceil(source_size / 1024)
+
    chunks_count = int(math.ceil(source_size / float(bytes_per_chunk)))
-   
-   if source_size > bytes_per_chunk:
+
+   if source_size > min_mp_size:
       mp = destBucket.initiate_multipart_upload(tmpFile)
 
       for i in range(chunks_count):


### PR DESCRIPTION
The errors handler tries to reference the destination buckets as "cfBucketName" and "s3BucketName" but all jobs contain the target bucket in the key "destBucketName". Without this change any upload errors will result in an exception.